### PR TITLE
fix(workflow): bypass membership check and drop synchronize trigger

### DIFF
--- a/.github/workflows/auto-copilot-pr-review.lock.yml
+++ b/.github/workflows/auto-copilot-pr-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6f054b69cb5bc9189b9f922e47a78387f24b5cdda645773852dd3c1a0d6a77af","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fa1adb73accfb349622d5c748da3ab688dbec7a9491bed349776a6d8779067d8","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -184,16 +184,16 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_6a108bb031501a4b_EOF'
+          cat << 'GH_AW_PROMPT_6ab83daadde34ee3_EOF'
           <system>
-          GH_AW_PROMPT_6a108bb031501a4b_EOF
+          GH_AW_PROMPT_6ab83daadde34ee3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6a108bb031501a4b_EOF'
+          cat << 'GH_AW_PROMPT_6ab83daadde34ee3_EOF'
           <safe-output-tools>
-          Tools: add_comment, missing_tool, missing_data, noop
+          Tools: add_comment, add_reviewer, missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -223,15 +223,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6a108bb031501a4b_EOF
+          GH_AW_PROMPT_6ab83daadde34ee3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_6a108bb031501a4b_EOF'
+          cat << 'GH_AW_PROMPT_6ab83daadde34ee3_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-copilot-pr-review.md}}
-          GH_AW_PROMPT_6a108bb031501a4b_EOF
+          GH_AW_PROMPT_6ab83daadde34ee3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -404,15 +404,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3d2d64dc1f01e52b_EOF'
-          {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3d2d64dc1f01e52b_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ca88a7b66dffd6e1_EOF'
+          {"add_comment":{"max":1},"add_reviewer":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_ca88a7b66dffd6e1_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading."
+                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading.",
+                "add_reviewer": " CONSTRAINTS: Maximum 1 reviewer(s) can be added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -438,6 +439,25 @@ jobs:
                   "repo": {
                     "type": "string",
                     "maxLength": 256
+                  }
+                }
+              },
+              "add_reviewer": {
+                "defaultMax": 3,
+                "fields": {
+                  "pull_request_number": {
+                    "issueOrPRNumber": true
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "reviewers": {
+                    "required": true,
+                    "type": "array",
+                    "itemType": "string",
+                    "itemSanitize": true,
+                    "itemMaxLength": 39
                   }
                 }
               },
@@ -590,7 +610,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_27c95c9eafc513e7_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_244483b95ca256b8_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -631,7 +651,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_27c95c9eafc513e7_EOF
+          GH_AW_MCP_CONFIG_244483b95ca256b8_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1162,6 +1182,7 @@ jobs:
       GH_AW_WORKFLOW_ID: "auto-copilot-pr-review"
       GH_AW_WORKFLOW_NAME: "Auto Copilot PR Review"
     outputs:
+      add_reviewer_reviewers_added: ${{ steps.process_safe_outputs.outputs.reviewers_added }}
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
       comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
@@ -1209,7 +1230,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_reviewer\":{\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/auto-copilot-pr-review.lock.yml
+++ b/.github/workflows/auto-copilot-pr-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"838d16d48806d3f7a33afa5e6168c7d1bdc1f5941b1946753f8c6c7ddf1704b7","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6f054b69cb5bc9189b9f922e47a78387f24b5cdda645773852dd3c1a0d6a77af","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -51,11 +51,11 @@ name: "Auto Copilot PR Review"
     types:
     - opened
     - reopened
-    - synchronize
   pull_request_review:
     types:
     - submitted
     - edited
+  # roles: all # Roles processed as role check in pre-activation job
   # skip-bots: # Skip-bots processed as bot check in pre-activation job
   # - copilot # Skip-bots processed as bot check in pre-activation job
   # - github-actions # Skip-bots processed as bot check in pre-activation job
@@ -184,14 +184,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f741496aae54ee5c_EOF'
+          cat << 'GH_AW_PROMPT_6a108bb031501a4b_EOF'
           <system>
-          GH_AW_PROMPT_f741496aae54ee5c_EOF
+          GH_AW_PROMPT_6a108bb031501a4b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f741496aae54ee5c_EOF'
+          cat << 'GH_AW_PROMPT_6a108bb031501a4b_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -223,15 +223,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_f741496aae54ee5c_EOF
+          GH_AW_PROMPT_6a108bb031501a4b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_f741496aae54ee5c_EOF'
+          cat << 'GH_AW_PROMPT_6a108bb031501a4b_EOF'
           </system>
           {{#runtime-import .github/workflows/auto-copilot-pr-review.md}}
-          GH_AW_PROMPT_f741496aae54ee5c_EOF
+          GH_AW_PROMPT_6a108bb031501a4b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -404,9 +404,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_340225632b22b6d2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3d2d64dc1f01e52b_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_340225632b22b6d2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3d2d64dc1f01e52b_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -590,7 +590,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_5499a8e9c4d9050b_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_27c95c9eafc513e7_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -631,7 +631,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5499a8e9c4d9050b_EOF
+          GH_AW_MCP_CONFIG_27c95c9eafc513e7_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1116,7 +1116,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
     runs-on: ubuntu-slim
     outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_skip_bots.outputs.skip_bots_ok == 'true' }}
+      activated: ${{ steps.check_skip_bots.outputs.skip_bots_ok == 'true' }}
       matched_command: ''
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
@@ -1126,18 +1126,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
       - name: Check skip-bots
         id: check_skip_bots
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9

--- a/.github/workflows/auto-copilot-pr-review.md
+++ b/.github/workflows/auto-copilot-pr-review.md
@@ -2,12 +2,20 @@
 description: Automatically request Copilot code review for pull requests.
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    # Intentionally omit `synchronize` so Copilot's own push commits
+    # (after an implementation handoff) do not re-trigger this workflow.
+    types: [opened, reopened]
   pull_request_review:
     types: [submitted, edited]
-  # Skip when Copilot itself is the actor — its identity is not a repo
-  # collaborator, so the gh-aw permission pre-activation check would fail
-  # ("Copilot is not a user"). Also prevents bot-to-bot loops.
+  # Required: the default membership check (`on.roles`) calls the repo
+  # collaborator permission API for `github.actor`. When the actor is the
+  # Copilot bot identity, that API errors with "Copilot is not a user" and
+  # fails pre-activation before `skip-bots` is evaluated. Allowing all roles
+  # bypasses the membership check; safety is preserved by
+  # `safe-outputs.add-comment.max: 1` and the skip-bots loop guard below.
+  roles: all
+  # Belt-and-suspenders loop prevention: also drop events whose actor is
+  # the Copilot or github-actions bot.
   skip-bots: [copilot, github-actions]
 permissions:
   contents: read

--- a/.github/workflows/auto-copilot-pr-review.md
+++ b/.github/workflows/auto-copilot-pr-review.md
@@ -25,6 +25,13 @@ tools:
   github:
     toolsets: [default]
 safe-outputs:
+  # Actually requests Copilot as a PR reviewer via the GitHub API
+  # (POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers)
+  # instead of just posting an `@copilot review` mention comment.
+  add-reviewer:
+    max: 1
+  # Used only for the conditional implementation handoff after Copilot's
+  # review surfaces actionable suggestions.
   add-comment:
     max: 1
   noop: {}
@@ -32,26 +39,23 @@ safe-outputs:
 
 # Auto Copilot PR Review
 
-You are an AI workflow agent that ensures pull requests get a Copilot code review request and only gets a Copilot implementation handoff after review suggestions exist.
+You are an AI workflow agent that ensures pull requests get Copilot assigned as a code reviewer and only posts a Copilot implementation handoff comment after review suggestions exist.
 
 ## Your Task
 
 1. Confirm the trigger references a pull request (`pull_request` or `pull_request_review`).
-2. Check whether the pull request already has a comment requesting Copilot review.
-3. If no review request exists, add one concise comment on the pull request timeline:
-
-@copilot review
-
-4. Inspect review outcomes and comments to determine whether actionable suggestions are present.
-5. Only if actionable suggestions exist and there is no existing implementation handoff comment, ask Copilot to implement with a second concise comment:
+2. Check whether `copilot-pull-request-reviewer` is already a requested reviewer or has already submitted a review on the pull request.
+3. If Copilot is not already a requested reviewer and has not already reviewed, request Copilot as a reviewer using the `add-reviewer` safe output with reviewer login `copilot-pull-request-reviewer`.
+4. Inspect review outcomes and review comments to determine whether actionable suggestions are present (a review with state `CHANGES_REQUESTED` or any non-empty review comments count as actionable).
+5. Only if actionable suggestions exist AND there is no existing implementation handoff comment from this workflow, post one concise comment with the `add-comment` safe output:
 
 @copilot please implement the requested simple changes directly in this PR and summarize what you changed.
 
 ## Rules
 
-- Do not post duplicate review request comments.
+- Do not request Copilot as a reviewer more than once per PR.
 - Do not post duplicate implementation handoff comments.
-- Never post implementation handoff before review suggestions exist.
-- If review has already been requested but no actionable suggestions exist yet, call `noop` with a brief explanation.
-- If implementation handoff already exists, call `noop` with a brief explanation.
+- Never post the implementation handoff before review suggestions exist.
+- If Copilot has already been requested as a reviewer but no actionable suggestions exist yet, call `noop` with a brief explanation.
+- If the implementation handoff already exists, call `noop` with a brief explanation.
 - Keep output minimal and deterministic.


### PR DESCRIPTION
- on.roles: all so the membership API call (which fails for Copilot with 'Copilot is not a user') is skipped before skip-bots can run

- Drop pull_request synchronize so Copilot's own push commits do not re-trigger the workflow

- Safety preserved by safe-outputs.add-comment.max: 1 and skip-bots loop guard